### PR TITLE
Fix error handling mishap +1

### DIFF
--- a/src/app/c/[id]/sign/_components/Form.tsx
+++ b/src/app/c/[id]/sign/_components/Form.tsx
@@ -9,10 +9,9 @@ import { useFormStatus } from "react-dom";
 
 export default function Form(props: { cardId: string }) {
   const clientFunction = async (formData: FormData) => {
-    try {
-      await createWish(formData, props.cardId);
-    } catch (error: unknown) {
-      if (error instanceof Error) toast(error.message);
+    const createResponse = await createWish(formData, props.cardId);
+    if (!createResponse.success) {
+      toast(createResponse.error);
       return;
     }
 

--- a/src/app/create/_components/Form.tsx
+++ b/src/app/create/_components/Form.tsx
@@ -10,17 +10,14 @@ import { useFormStatus } from "react-dom";
 
 export default function Form() {
   const clientFunction = async (formData: FormData) => {
-    let cardResponse: CardData;
-
-    try {
-      cardResponse = await createCard(formData);
-    } catch (error: unknown) {
-      if (error instanceof Error) toast(error.message);
+    const cardResponse = await createCard(formData);
+    if (!cardResponse.success) {
+      toast(cardResponse.error);
       return;
     }
 
     setTimeout(() => {
-      location.href = `/c/${cardResponse.id}`;
+      location.href = `/c/${cardResponse.data.id}`;
     }, 1500);
   };
 

--- a/src/components/signatures/manage.tsx
+++ b/src/components/signatures/manage.tsx
@@ -19,10 +19,9 @@ export const EditWishDialog = (props: {
 }) => {
   const clientFunction = async (formData: FormData) => {
     const newWish = formData.get("wish") as string;
-    try {
-      await updateWish(props.signature.id, newWish);
-    } catch (error: unknown) {
-      if (error instanceof Error) toast(error.message);
+    const updateResponse = await updateWish(props.signature.id, newWish);
+    if (!updateResponse.success) {
+      toast(updateResponse.error);
       return;
     }
     toast("Wish has been updated.");

--- a/src/server/actions/updateWish.ts
+++ b/src/server/actions/updateWish.ts
@@ -16,14 +16,6 @@ export const updateWish = async (
     return { success: false, error: "You cannot send empty wishes" };
   }
 
-  const wish = (
-    await db.select().from(wishSchema).where(eq(wishSchema.id, wishId))
-  ).shift();
-
-  if (!wish) {
-    return { success: false, error: "Wish not found" };
-  }
-
   const newWish = await db
     .update(wishSchema)
     .set({
@@ -31,6 +23,8 @@ export const updateWish = async (
     })
     .where(eq(wishSchema.id, wishId))
     .returning();
-
-  return { success: true, data: newWish.shift() as Wishes };
+  if (newWish.length === 0) {
+    return { success: false, error: "Wish not found" };
+  }
+  return { success: true, data: newWish[0] as Wishes };
 };

--- a/src/server/actions/updateWish.ts
+++ b/src/server/actions/updateWish.ts
@@ -4,12 +4,16 @@ import { db } from "~/server/db/";
 import { eq } from "drizzle-orm";
 import { type Wishes, wishes as wishSchema } from "~/server/db/schema";
 
+export type UpdateWishResult =
+  | { success: true; data: Wishes }
+  | { success: false; error: string };
+
 export const updateWish = async (
   wishId: string,
   wishText: string,
-): Promise<Wishes | undefined> => {
+): Promise<UpdateWishResult> => {
   if (wishText.trim().length === 0) {
-    throw new Error("You cannot send empty wishes");
+    return { success: false, error: "You cannot send empty wishes" };
   }
 
   const wish = (
@@ -17,7 +21,7 @@ export const updateWish = async (
   ).shift();
 
   if (!wish) {
-    throw new Error("Wish not found");
+    return { success: false, error: "Wish not found" };
   }
 
   const newWish = await db
@@ -27,5 +31,6 @@ export const updateWish = async (
     })
     .where(eq(wishSchema.id, wishId))
     .returning();
-  return newWish.shift();
+
+  return { success: true, data: newWish.shift() as Wishes };
 };


### PR DESCRIPTION
This PR fixes an issue introduced in #6. Errors from server actions are now returned inside of a result type instead of those errors being thrown and left unhandled. This should work nicer with Next.js (hopefully).

+1 fix: Remove a redundant DB call when editing a wish. We can check if the wish exists with just one call. If the wish doesn't exist, the returning wishes list will have a length of 0.